### PR TITLE
Compressed logging 2

### DIFF
--- a/include/byte_aggregator.h
+++ b/include/byte_aggregator.h
@@ -1,0 +1,52 @@
+#ifndef BYTE_AGGREGATOR_H
+#define BYTE_AGGREGATOR_H
+
+#include <vector>
+#include <stdint.h>
+#include <stdexcept>
+#include <iostream>
+
+namespace utils {
+// AggrBytes is a compressed representation of a series of identical bytes.
+// 
+// It is encoded over 2 bytes if is8, else 3.
+struct AggrBytes {
+  // val is the value of the repeated byte, necessarily < 0x80
+  uint8_t val;
+  // count is the number of times val is repeated
+  uint16_t count;
+  // is8 indicates whether count can hold on only one byte instead of 2
+  bool is8;
+
+  AggrBytes(): val(0), count(0), is8(true) {}
+};
+
+// Read and write AggrBytes
+std::ostream& operator<< (std::ostream& out, AggrBytes& ab);
+std::istream& operator>> (std::istream& in, AggrBytes& ab);
+
+// ByteAggregator will aggregate indentical bytes into an AggrBytes. Reusable.
+class ByteAggregator {
+  public:
+    // MAX is the maximum tolerated value for load()
+    static const int MAX = 0x7f;
+    // CAP is the number of bytes the aggregator can take before needing to reset
+    static const int CAP = 0xffff;
+    // load a byte into the aggregator. Byte has to be <= MAX
+    void load(uint8_t byte);
+    // canLoad returns true if additional byte can be aggregated (equal to the
+    // internal value, and capacity not exceeded)
+    bool canLoad(uint8_t byte);
+    // aggregate everything that was loaded into the aggregator
+    AggrBytes aggregate();
+    // reset the aggregator 
+    void reset();
+
+    // capacity is the number of bytes the aggregator can take before needing to reset
+    ByteAggregator(int capacity);
+  private:
+    AggrBytes aggr;
+    bool locked;
+};
+}
+#endif

--- a/include/screenstream.h
+++ b/include/screenstream.h
@@ -43,19 +43,6 @@ class ScreenStream {
     uint8_t read();
   private:
     std::fstream stream;
-    // diffs is of length screenSize/8, where each bit represents one pixel with
-    // a value of 0 if its color value stayed the same, 1 if it changed
-    std::vector<uint8_t> diffs;
-    // colors is of length screenSize, each byte being the current color of a
-    // pixel.
-    std::vector<uint8_t> colors;
-    // it points to where we currently are in colors and diffs
-    int it;
-
-    // colorDiffs stores the colors of the pixels which color actually changed
-    std::vector<uint8_t> colorDiffs;
-
-    ByteAggregator diffAggregator;
     ByteAggregator colorAggregator;
 };
 } // namespace utils

--- a/include/screenstream.h
+++ b/include/screenstream.h
@@ -6,45 +6,32 @@
 #include <vector>
 
 #include "streams.h"
+#include "byte_aggregator.h"
 
 namespace utils {
 // SCREENSTREAM_END is the value found at the end of files produced by
 // ScreenStream (an EOF of sorts)
 const uint8_t SCREENSTREAM_END = 255;
 
-// ByteAggregator will aggregate indentical values. Reusable.
-class ByteAggregator {
-  public:
-    // load a byte into the aggregator
-    void load(uint8_t byte);
-    // canLoad returns true if additional byte can be aggregated (equal to the
-    // internal value, and capacity not exceeded)
-    bool canLoad(uint8_t byte);
-    // aggregate everything that was loaded into the aggregator
-    std::vector<uint8_t> aggregate();
-    // reset the aggregator 
-    void reset();
-    // capacity is the number of bytes the aggregator can take before needing to reset
-    ByteAggregator(int capacity);
-  private:
-    uint8_t val;
-    int count;
-    int cap;
-    bool locked;
-};
-
+// ScreenStream is a wrapper around a bit stream that writes palette palette
+// values to a file, compressing them in the process. Conversly, it can also
+// decompress it to return the values in the same order.
 class ScreenStream {
   public:
     // XXX: screenSize is supposed to be a multiple of 8
     ScreenStream(std::string fileName, StreamMode mode, int screenSize);
+    // write palette to the file, assuming palette is < 64
     void write(uint8_t palette);
-    void close();
-    // read returns the next byte as an int
+    // read the palette value. The nth call to read() is guaranteed to return
+    // the same value that was written with the nth call to write().
     uint8_t read();
+    // close the underlying stream. As output is bufferized, this must be called
+    // in order to avoid missing data
+    void close();
   private:
     std::fstream stream;
-    uint8_t currentColor;
-    uint16_t count;
+
+    AggrBytes currentColor;
     ByteAggregator colorAggregator;
 };
 } // namespace utils

--- a/include/screenstream.h
+++ b/include/screenstream.h
@@ -12,6 +12,27 @@ namespace utils {
 // ScreenStream (an EOF of sorts)
 const uint8_t SCREENSTREAM_END = 255;
 
+// ByteAggregator will aggregate indentical values. Reusable.
+class ByteAggregator {
+  public:
+    // load a byte into the aggregator
+    void load(uint8_t byte);
+    // canLoad returns true if additional byte can be aggregated (equal to the
+    // internal value, and capacity not exceeded)
+    bool canLoad(uint8_t byte);
+    // aggregate everything that was loaded into the aggregator
+    std::vector<uint8_t> aggregate();
+    // reset the aggregator 
+    void reset();
+    // capacity is the number of bytes the aggregator can take before needing to reset
+    ByteAggregator(int capacity);
+  private:
+    uint8_t val;
+    int count;
+    int cap;
+    bool locked;
+};
+
 class ScreenStream {
   public:
     // XXX: screenSize is supposed to be a multiple of 8
@@ -33,6 +54,9 @@ class ScreenStream {
 
     // colorDiffs stores the colors of the pixels which color actually changed
     std::vector<uint8_t> colorDiffs;
+
+    ByteAggregator diffAggregator;
+    ByteAggregator colorAggregator;
 };
 } // namespace utils
 

--- a/include/screenstream.h
+++ b/include/screenstream.h
@@ -43,6 +43,8 @@ class ScreenStream {
     uint8_t read();
   private:
     std::fstream stream;
+    uint8_t currentColor;
+    uint16_t count;
     ByteAggregator colorAggregator;
 };
 } // namespace utils

--- a/include/screenstream.h
+++ b/include/screenstream.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <fstream>
+#include <vector>
 
 #include "streams.h"
 
@@ -13,13 +14,25 @@ const uint8_t SCREENSTREAM_END = 255;
 
 class ScreenStream {
   public:
-    ScreenStream(std::string fileName, StreamMode mode);
+    // XXX: screenSize is supposed to be a multiple of 8
+    ScreenStream(std::string fileName, StreamMode mode, int screenSize);
     void write(uint8_t palette);
     void close();
     // read returns the next byte as an int
     uint8_t read();
   private:
     std::fstream stream;
+    // diffs is of length screenSize/8, where each bit represents one pixel with
+    // a value of 0 if its color value stayed the same, 1 if it changed
+    std::vector<uint8_t> diffs;
+    // colors is of length screenSize, each byte being the current color of a
+    // pixel.
+    std::vector<uint8_t> colors;
+    // it points to where we currently are in colors and diffs
+    int it;
+
+    // colorDiffs stores the colors of the pixels which color actually changed
+    std::vector<uint8_t> colorDiffs;
 };
 } // namespace utils
 

--- a/nes.cpp
+++ b/nes.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
     return -1;
   } 
   std::string path(argv[1]);
-  Console console(path, InterfaceType::DEBUG_INTERFACE);
+  Console console(path, InterfaceType::MONITOR);
   while (console.isRunning()) {
     console.step();
   }

--- a/nes.cpp
+++ b/nes.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
     return -1;
   } 
   std::string path(argv[1]);
-  Console console(path, InterfaceType::REPLAY);
+  Console console(path, InterfaceType::DEBUG_INTERFACE);
   while (console.isRunning()) {
     console.step();
   }

--- a/nes.cpp
+++ b/nes.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
     return -1;
   } 
   std::string path(argv[1]);
-  Console console(path, InterfaceType::MONITOR);
+  Console console(path, InterfaceType::REPLAY);
   while (console.isRunning()) {
     console.step();
   }

--- a/nes.cpp
+++ b/nes.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[]) {
     return -1;
   } 
   std::string path(argv[1]);
-  Console console(path, InterfaceType::DEBUG_INTERFACE);
+  Console console(path, InterfaceType::REPLAY);
   while (console.isRunning()) {
     console.step();
   }

--- a/src/io_interface/compare_interface.cpp
+++ b/src/io_interface/compare_interface.cpp
@@ -8,7 +8,7 @@
 CompareInterface::CompareInterface(InterfaceType t):
   target(IOInterface::newIOInterface(t)),
   btnStream("buttons.log", utils::StreamMode::IN),
-  screenStream("screen.log", utils::StreamMode::IN),
+  screenStream("screen.log", utils::StreamMode::IN, IOInterface::WIDTH*IOInterface::HEIGHT),
   remainingCount(0), currentButtons({0}), 
   remainingRstCount(0), currentReset(false), isDone(false)
 {

--- a/src/io_interface/replay_interface.cpp
+++ b/src/io_interface/replay_interface.cpp
@@ -4,7 +4,7 @@
 
 ReplayInterface::ReplayInterface(InterfaceType t):
   target(IOInterface::newIOInterface(t)),
-  screenStream("screen.log", utils::StreamMode::IN),
+  screenStream("screen.log", utils::StreamMode::IN, IOInterface::WIDTH*IOInterface::HEIGHT),
   isClose(false)
 {}
 

--- a/src/io_interface/replay_interface.cpp
+++ b/src/io_interface/replay_interface.cpp
@@ -19,11 +19,20 @@ void ReplayInterface::render() {
 }
 
 void ReplayInterface::colorPixel(int x, int y, int palette) {
+  // Due to how the ppu (calling colorPixel) cycles several times for each cpu
+  // (calling shouldClose()) cycle, it is possible that we try to render a few
+  // more pixels before realizing that in fact we should be done.
+  // Return straight away to avoid any problems.
+  if (isClose) {
+    return;
+  }
+
   uint8_t val = screenStream.read();
   if (val == utils::SCREENSTREAM_END) {
     isClose = true;
     return;
   }
+
   target->colorPixel(x, y, (int)val);
 }
 

--- a/src/io_interface/spy_interface.cpp
+++ b/src/io_interface/spy_interface.cpp
@@ -7,7 +7,7 @@
 
 SpyInterface::SpyInterface(InterfaceType t):
   target(IOInterface::newIOInterface(t)),
-  screenStream("screen.log", utils::StreamMode::OUT), 
+  screenStream("screen.log", utils::StreamMode::OUT, IOInterface::WIDTH*IOInterface::HEIGHT), 
   btnStream("buttons.log", utils::StreamMode::OUT),
   identicalCount(0), currentButtons({0}), 
   identicalRstCount(0), currentReset(false)

--- a/src/utils/byte_aggregator.cpp
+++ b/src/utils/byte_aggregator.cpp
@@ -1,0 +1,116 @@
+#include "byte_aggregator.h"
+
+namespace utils {
+std::ostream& operator<< (std::ostream& out, AggrBytes& ab) {
+  if (ab.is8) {
+    out.write((char*)&ab.val, sizeof(uint8_t));
+    uint8_t smallCount = ab.count & 0xff;
+    out.write((char*)&smallCount, sizeof(uint8_t));
+    return out;
+  }
+
+  // signify that count is encoded over two bytes by setting the msb of value
+  uint8_t outVal = ab.val | 0x80;
+  out.write((char*)&outVal, sizeof(uint8_t));
+  out.write((char*)&ab.count, sizeof(uint16_t));
+
+  return out;
+}
+
+std::istream& operator>> (std::istream& in, AggrBytes& ab) {
+  uint8_t inVal;
+  in.read((char*)&inVal, sizeof(uint8_t));
+
+  // Discard msb
+  ab.val = inVal & 0x7f;
+
+  if (inVal >> 7 == 0) {
+    ab.is8 = true;
+    in.read((char*)&ab.count, sizeof(uint8_t)); 
+    return in;
+  }
+
+  ab.is8 = false;
+  in.read((char*)&ab.count, sizeof(uint16_t));
+  return in;
+}
+
+ByteAggregator::ByteAggregator(int capacity): locked(false) {}
+
+void ByteAggregator::load(uint8_t byte) {
+  if (byte >= ByteAggregator::MAX) {
+    throw std::runtime_error("writing a value too big to byteAggregator");
+  }
+
+  if (locked && byte != aggr.val) {
+    throw std::runtime_error("writing a different value to a locked ByteAggregator");
+  }
+
+  if (aggr.count == ByteAggregator::CAP) {
+    throw std::runtime_error("writing to a full ByteAggregator");
+  }
+
+  if (!locked) {
+    aggr.val = byte;
+    locked = true;
+  }
+
+  if (aggr.count == 0xff) {
+    aggr.is8 = false;
+  }
+
+  aggr.count++;
+}
+
+bool ByteAggregator::canLoad(uint8_t byte) {
+  if (aggr.count == ByteAggregator::CAP) {
+    return false;
+  }
+
+  if (locked && byte != aggr.val) {
+    return false;
+  }
+
+  return true;
+}
+
+AggrBytes ByteAggregator::aggregate() {
+  return aggr;
+}
+//   // std::cout << (int) val << " count=" << count << "\n";
+// 
+//   // TODO: this should probably use the write() function to ensure endianess is
+//   // correct? Right now we write in little endian so if the platform is little
+//   // endian then it can decode, else no
+//   uint8_t b = count & 0xff;
+//   r.push_back(b);
+//   count >>= 8;
+// 
+//   // we have a bigger count, set val higher bit to 1 to signify "bigger
+//   // aggregator"
+//   if (count != 0) {
+//     uint8_t b = count & 0xff;
+//     r.push_back(b);
+//     count >>= 8;
+//     // Set msb to 1, signifying to the decoded that this value has 2 bytes of
+//     // count instead of one
+//     val |= 0x80;
+//   }
+// 
+//   if (count != 0) {
+//     // this should not happen
+//     throw std::runtime_error("aggregated on more than 2 count bytes");
+//   }
+//   
+//   // put it at the beginning, so the decoder knows how many bytes of count it
+//   // will need to read
+//   r.insert(r.begin(), val);
+//   return r;
+// }
+
+void ByteAggregator::reset() {
+  locked = false;
+  aggr = AggrBytes();
+}
+} // namespace utils
+

--- a/src/utils/screenstream.cpp
+++ b/src/utils/screenstream.cpp
@@ -6,6 +6,10 @@ ByteAggregator::ByteAggregator(int capacity):
   val(0), count(0), cap(capacity), locked(false) {}
 
 void ByteAggregator::load(uint8_t byte) {
+  if (byte > 0b01111111) {
+    throw std::runtime_error("writing a value > 127 to byteAggregator");
+  }
+
   if (locked && byte != val) {
     throw std::runtime_error("writing a different value to a locked ByteAggregator");
   }
@@ -36,13 +40,30 @@ bool ByteAggregator::canLoad(uint8_t byte) {
 
 std::vector<uint8_t> ByteAggregator::aggregate() {
   std::vector<uint8_t> r;
-  r.push_back(val);
   // std::cout << (int) val << " count=" << count << "\n";
-  while (count != 0) {
+  uint8_t b = count & 0xff;
+  r.push_back(b);
+  count >>= 8;
+
+  // we have a bigger count, set val higher bit to 1 to signify "bigger
+  // aggregator"
+  if (count != 0) {
     uint8_t b = count & 0xff;
     r.push_back(b);
     count >>= 8;
+    // Set msb to 1, signifying to the decoded that this value has 2 bytes of
+    // count instead of one
+    val |= 0x8;
   }
+
+  if (count != 0) {
+    // this should not happen
+    throw std::runtime_error("aggregated on more than 2 count bytes");
+  }
+  
+  // put it at the beginning, so the decoder knows how many bytes of count it
+  // will need to read
+  r.insert(r.begin(), val);
   return r;
 }
 
@@ -52,8 +73,7 @@ void ByteAggregator::reset() {
 }
 
 ScreenStream::ScreenStream(std::string fileName, StreamMode mode, int screenSize):
-  diffs(screenSize/8), colors(screenSize, 255), it(0),
-  diffAggregator(0xffff), colorAggregator(0xffff)
+  colorAggregator(0xffff)
 {
   switch (mode) {
     case StreamMode::IN:
@@ -63,89 +83,21 @@ ScreenStream::ScreenStream(std::string fileName, StreamMode mode, int screenSize
       stream.open(fileName, std::ios::binary | std::ios::out);
       break;
   }
-  // We know the maximal size of all vectors, so reserve it from the start to
-  // avoid useless relocations
-  colorDiffs.reserve(screenSize);
 }
 
 void ScreenStream::write(uint8_t palette) {
-  // for diffs, it points to a bit, not to a byte
-  int diffIndex = it / 8;
-  // it goes from left to right, but inside one diff the offset goes right to
-  // left
-  int diffOffset = 7 - it % 8;
-
-  // update diffs array
-  uint8_t prevColor = colors[it];
-  uint8_t currDiff = diffs[diffIndex];
-  if (palette != prevColor) {
-    // 0 everywhere except where the diff is, then bitwise OR to set it while
-    // preserving the rest
-    uint8_t filter = 1 << diffOffset; 
-    diffs[diffIndex] = currDiff | filter;
-    // add palette to color buffer
-    colorDiffs.push_back(palette);
-  } else {
-    // 1 everywhere except where the diff is, then bitwise AND to set it while
-    // preserving the rest
-    uint8_t filter = ~(1 << diffOffset);
-    diffs[diffIndex] = currDiff & filter; 
-  }
-
-  // update colors array
-  colors[it] = palette;
-  // go to next pixel
-  it++;
-
-  if (diffOffset == 7) {
-    // we just finished writing one full byte, send it to the file
-    // if the aggregator is full (meaning we changed value), then aggregate and
-    // write, otherwise load the value in the aggregator and move on
-    if (!diffAggregator.canLoad(diffs[diffIndex])) {
-      auto aggregated = diffAggregator.aggregate();
-      // std::cout << "writing diffByte=" << aggregated.size() << "\n";
-      stream.write((char*)aggregated.data(), aggregated.size());
-      diffAggregator.reset();
-    }
-    diffAggregator.load(diffs[diffIndex]);
-  }
-
-  if (it == (colors.size() - 1)) {
-    // we're done with one full screen, write additional info
-    // first, write any diff leftovers
-    auto aggregatedDiffs = diffAggregator.aggregate();
-    stream.write((char*)aggregatedDiffs.data(), aggregatedDiffs.size());
-
-    // aggregate colorDiffs
-    std::vector<uint8_t> compressed, aggregated;
-    for (auto it = colorDiffs.begin(); it != colorDiffs.end(); it ++) {
-      if (!colorAggregator.canLoad(*it)) {
-        aggregated = colorAggregator.aggregate();
-        compressed.insert(compressed.end(), aggregated.begin(), aggregated.end());
-        colorAggregator.reset();
-      }
-      colorAggregator.load(*it);
-    }
-
-    // aggregate the leftovers as well
-    aggregated = colorAggregator.aggregate();
-    compressed.insert(compressed.end(), aggregated.begin(), aggregated.end());
-
-    // compressed should not have more than 2 * 240 * 256 bytes
-    int compressedSize = compressed.size();
-    // std::cout << "writing colorDiffsSize=" << compressed.size() << "\n";
-    stream.write((char*)&compressedSize, sizeof(int));
-    stream.write((char*)compressed.data(), compressed.size());
-
-    // finally, resize colorDiffs for another loop
-    diffAggregator.reset();
+  if (!colorAggregator.canLoad(palette)) {
+    auto aggregated = colorAggregator.aggregate();
+    // std::cout << aggregated.size() << "\n";
+    stream.write((char*)aggregated.data(), aggregated.size());
     colorAggregator.reset();
-    colorDiffs.resize(0);
-    it = 0;
   }
+  colorAggregator.load(palette);
 }
 
 void ScreenStream::close() {
+  auto leftover = colorAggregator.aggregate();
+  stream.write((char*)leftover.data(), leftover.size());
   stream.write((char*)&SCREENSTREAM_END, sizeof(SCREENSTREAM_END));
   stream.close();
 }

--- a/src/utils/screenstream.cpp
+++ b/src/utils/screenstream.cpp
@@ -41,6 +41,10 @@ bool ByteAggregator::canLoad(uint8_t byte) {
 std::vector<uint8_t> ByteAggregator::aggregate() {
   std::vector<uint8_t> r;
   // std::cout << (int) val << " count=" << count << "\n";
+
+  // TODO: this should probably use the write() function to ensure endianess is
+  // correct? Right now we write in little endian so if the platform is little
+  // endian then it can decode, else no
   uint8_t b = count & 0xff;
   r.push_back(b);
   count >>= 8;
@@ -112,6 +116,13 @@ uint8_t ScreenStream::read() {
 
   uint8_t byte;
   stream.read((char*)&byte, sizeof(byte));
+
+  // XXX: Because we know that we never write anything > 63 (0x3f) to the
+  // ByteAggregator, the only way we get something bigger than 0xbf is when we
+  // stumble upon SCREENSTREAM_END, in which case we can return directly
+  if (byte == SCREENSTREAM_END) {
+    return SCREENSTREAM_END;
+  }
 
   // discard msb
   currentColor = byte & 0x7f;

--- a/src/utils/screenstream.cpp
+++ b/src/utils/screenstream.cpp
@@ -2,82 +2,8 @@
 #include <iostream>
 
 namespace utils {
-ByteAggregator::ByteAggregator(int capacity):
-  val(0), count(0), cap(capacity), locked(false) {}
-
-void ByteAggregator::load(uint8_t byte) {
-  if (byte > 0b01111111) {
-    throw std::runtime_error("writing a value > 127 to byteAggregator");
-  }
-
-  if (locked && byte != val) {
-    throw std::runtime_error("writing a different value to a locked ByteAggregator");
-  }
-
-  if (count == cap) {
-    throw std::runtime_error("writing to a full ByteAggregator");
-  }
-
-  if (!locked) {
-    val = byte;
-    locked = true;
-  }
-
-  count++;
-}
-
-bool ByteAggregator::canLoad(uint8_t byte) {
-  if (count == cap) {
-    return false;
-  }
-
-  if (locked && byte != val) {
-    return false;
-  }
-
-  return true;
-}
-
-std::vector<uint8_t> ByteAggregator::aggregate() {
-  std::vector<uint8_t> r;
-  // std::cout << (int) val << " count=" << count << "\n";
-
-  // TODO: this should probably use the write() function to ensure endianess is
-  // correct? Right now we write in little endian so if the platform is little
-  // endian then it can decode, else no
-  uint8_t b = count & 0xff;
-  r.push_back(b);
-  count >>= 8;
-
-  // we have a bigger count, set val higher bit to 1 to signify "bigger
-  // aggregator"
-  if (count != 0) {
-    uint8_t b = count & 0xff;
-    r.push_back(b);
-    count >>= 8;
-    // Set msb to 1, signifying to the decoded that this value has 2 bytes of
-    // count instead of one
-    val |= 0x80;
-  }
-
-  if (count != 0) {
-    // this should not happen
-    throw std::runtime_error("aggregated on more than 2 count bytes");
-  }
-  
-  // put it at the beginning, so the decoder knows how many bytes of count it
-  // will need to read
-  r.insert(r.begin(), val);
-  return r;
-}
-
-void ByteAggregator::reset() {
-  locked = false;
-  count = 0;
-}
-
 ScreenStream::ScreenStream(std::string fileName, StreamMode mode, int screenSize):
-  colorAggregator(0xffff), currentColor(0), count(0)
+  colorAggregator(0xffff)
 {
   switch (mode) {
     case StreamMode::IN:
@@ -89,13 +15,10 @@ ScreenStream::ScreenStream(std::string fileName, StreamMode mode, int screenSize
   }
 }
 
-int writeCounter = 0;
 void ScreenStream::write(uint8_t palette) {
   if (!colorAggregator.canLoad(palette)) {
     auto aggregated = colorAggregator.aggregate();
-    // std::cout << aggregated.size() << "\n";
-    stream.write((char*)aggregated.data(), aggregated.size());
-    writeCounter ++;
+    stream << aggregated;
     colorAggregator.reset();
   }
   colorAggregator.load(palette);
@@ -103,41 +26,47 @@ void ScreenStream::write(uint8_t palette) {
 
 void ScreenStream::close() {
   auto leftover = colorAggregator.aggregate();
-  stream.write((char*)leftover.data(), leftover.size());
+  stream << leftover;
   stream.write((char*)&SCREENSTREAM_END, sizeof(SCREENSTREAM_END));
   stream.close();
 }
 
 uint8_t ScreenStream::read() {
-  if (count != 0) {
-    count--;
-    return currentColor;
+  if (currentColor.count != 0) {
+    currentColor.count--;
+    return currentColor.val;
   }
 
-  uint8_t byte;
-  stream.read((char*)&byte, sizeof(byte));
-
-  // XXX: Because we know that we never write anything > 63 (0x3f) to the
-  // ByteAggregator, the only way we get something bigger than 0xbf is when we
-  // stumble upon SCREENSTREAM_END, in which case we can return directly
-  if (byte == SCREENSTREAM_END) {
+  if ((uint8_t)stream.peek() == SCREENSTREAM_END) {
     return SCREENSTREAM_END;
   }
 
-  // discard msb
-  currentColor = byte & 0x7f;
-  // decide how to fill count depending on the msb
-  if ((byte >> 7) == 0) {
-    // in this case, we have only one byte of count, so reuse byte
-    stream.read((char*)&byte, sizeof(byte));
-    count = byte;
-  } else {
-    // in this case, we have only one byte of count, so reuse byte
-    stream.read((char*)&count, sizeof(count));
-  }
+  stream >> currentColor;
 
-  count--;
-  return currentColor;
+  // uint8_t byte;
+  // stream.read((char*)&byte, sizeof(byte));
+
+  // // XXX: Because we know that we never write anything > 63 (0x3f) to the
+  // // ByteAggregator, the only way we get something bigger than 0xbf is when we
+  // // stumble upon SCREENSTREAM_END, in which case we can return directly
+  // if (byte == SCREENSTREAM_END) {
+  //   return SCREENSTREAM_END;
+  // }
+
+  // // discard msb
+  // currentColor = byte & 0x7f;
+  // // decide how to fill count depending on the msb
+  // if ((byte >> 7) == 0) {
+  //   // in this case, we have only one byte of count, so reuse byte
+  //   stream.read((char*)&byte, sizeof(byte));
+  //   count = byte;
+  // } else {
+  //   // in this case, we have only one byte of count, so reuse byte
+  //   stream.read((char*)&count, sizeof(count));
+  // }
+
+  currentColor.count--;
+  return currentColor.val;
 }
 } // namespace utils
 

--- a/src/utils/screenstream.cpp
+++ b/src/utils/screenstream.cpp
@@ -2,7 +2,9 @@
 #include <iostream>
 
 namespace utils {
-ScreenStream::ScreenStream(std::string fileName, StreamMode mode) {
+ScreenStream::ScreenStream(std::string fileName, StreamMode mode, int screenSize):
+  diffs(screenSize/8), colors(screenSize, 255), it(0)
+{
   switch (mode) {
     case StreamMode::IN:
       stream.open(fileName, std::ios::binary | std::ios::in);
@@ -11,10 +13,56 @@ ScreenStream::ScreenStream(std::string fileName, StreamMode mode) {
       stream.open(fileName, std::ios::binary | std::ios::out);
       break;
   }
+  // We know the maximal size of all vectors, so reserve it from the start to
+  // avoid useless relocations
+  colorDiffs.reserve(screenSize);
 }
 
 void ScreenStream::write(uint8_t palette) {
-  stream.write((char*)&palette, sizeof(palette));
+  // for diffs, it points to a bit, not to a byte
+  int diffIndex = it / 8;
+  // it goes from left to right, but inside one diff the offset goes right to
+  // left
+  int diffOffset = 7 - it % 8;
+
+  // update diffs array
+  uint8_t prevColor = colors[it];
+  uint8_t currDiff = diffs[diffIndex];
+  if (palette != prevColor) {
+    // 0 everywhere except where the diff is, then bitwise OR to set it while
+    // preserving the rest
+    uint8_t filter = 1 << diffOffset; 
+    diffs[diffIndex] = currDiff | filter;
+    // add palette to color buffer
+    colorDiffs.push_back(palette);
+  } else {
+    // 1 everywhere except where the diff is, then bitwise AND to set it while
+    // preserving the rest
+    uint8_t filter = ~(1 << diffOffset);
+    diffs[diffIndex] = currDiff & filter; 
+  }
+
+  // update colors array
+  colors[it] = palette;
+  // go to next pixel
+  it++;
+
+  if (diffOffset == 7) {
+    // we just finished writing one full byte, send it to the file
+    stream.write((char*)&diffs[diffIndex], sizeof(uint8_t));
+  }
+
+  if (it == (colors.size() - 1)) {
+    // we're done with one full screen, write additional info'
+    uint16_t colorDiffsSize = colorDiffs.size();
+    std::cout << "writing colorDiffsSize=" << colorDiffs.size() << "\n";
+    stream.write((char*)&colorDiffsSize, sizeof(uint8_t));
+    stream.write((char*)colorDiffs.data(), colorDiffs.size());
+
+    // finally, resize colorDiffs for another loop
+    colorDiffs.resize(0);
+    it = 0;
+  }
 }
 
 void ScreenStream::close() {


### PR DESCRIPTION
Do smarter logging on the screen contents to limit file size.

**For a sample test file**

OLD | NEW
-------|-------
`18MB` | `420KB`

**For about 15s of donkey kong**

OLD | NEW
-------|-------
`63MB` | `8MB`

This works by aggregating together similar bytes and outputting an aggregated `(value, count)` instead of `value * count`.